### PR TITLE
(#3) Do not use -p 6601

### DIFF
--- a/rofi-mpd
+++ b/rofi-mpd
@@ -10,57 +10,57 @@ ROFI="rofi -dmenu -p 'Search:'"
 addaftercurrent(){
 	
 	#playlist is empty, just add the song
-	if [ "$(mpc -p 6601 playlist | wc -l)" == "0" ]; then
-		mpc -p 6601 add "$1" 
+	if [ "$(mpc playlist | wc -l)" == "0" ]; then
+		mpc add "$1" 
 
 	#there is no current song so mpd is stopped
 	#it seems to be impossible to determine the current songs' position when 
 	#mpd is stopped, so just add to the end
-	elif [ -z "$(mpc -p 6601 current)" ]; then 
-		mpc -p 6601 play
-		CUR_POS=$(mpc -p 6601  | tail -2 | head -1 | awk '{print $2}' | sed 's/#//' | awk -F/ '{print $1}')
-		END_POS=$(mpc -p 6601 playlist | wc -l)
-		mpc -p 6601 add "$1"
-		mpc -p 6601 move $(($END_POS+1)) $(($CUR_POS+1))	
-		mpc -p 6601 stop
+	elif [ -z "$(mpc current)" ]; then 
+		mpc play
+		CUR_POS=$(mpc  | tail -2 | head -1 | awk '{print $2}' | sed 's/#//' | awk -F/ '{print $1}')
+		END_POS=$(mpc playlist | wc -l)
+		mpc add "$1"
+		mpc move $(($END_POS+1)) $(($CUR_POS+1))	
+		mpc stop
 
 	#at least 1 song is in the playlist, determine the position of the 
 	#currently played song and add $1 after it
 	else
 
-		CUR_POS=$(mpc -p 6601  | tail -2 | head -1 | awk '{print $2}' | sed 's/#//' | awk -F/ '{print $1}')
-		END_POS=$(mpc -p 6601 playlist | wc -l)
-		mpc -p 6601 add "$1"
-		mpc -p 6601 move $(($END_POS+1)) $(($CUR_POS+1))	
+		CUR_POS=$(mpc  | tail -2 | head -1 | awk '{print $2}' | sed 's/#//' | awk -F/ '{print $1}')
+		END_POS=$(mpc playlist | wc -l)
+		mpc add "$1"
+		mpc move $(($END_POS+1)) $(($CUR_POS+1))	
 	fi
 }
 addaftercurrentandplay(){
 
 	#playlist is empty, just add the song
-	if [ "$(mpc -p 6601 playlist | wc -l)" == "0" ]; then
-		mpc -p 6601 add "$1" 
-		mpc -p 6601 play
+	if [ "$(mpc playlist | wc -l)" == "0" ]; then
+		mpc add "$1" 
+		mpc play
 
 	#there is no current song so mpd is stopped
 	#it seems to be impossible to determine the current songs' position when 
 	#mpd is stopped, so just add to the end
-	elif [ -z "$(mpc -p 6601 current)" ]; then 
-		mpc -p 6601play
-		CUR_POS=$(mpc -p 6601  | tail -2 | head -1 | awk '{print $2}' | sed 's/#//' | awk -F/ '{print $1}')
-		END_POS=$(mpc -p 6601 playlist | wc -l)
-		mpc -p 6601 add "$1"
-		mpc -p 6601 move $(($END_POS+1)) $(($CUR_POS+1))	
-		mpc -p 6601 play $(($CUR_POS+1))
+	elif [ -z "$(mpc current)" ]; then 
+		mpc play
+		CUR_POS=$(mpc  | tail -2 | head -1 | awk '{print $2}' | sed 's/#//' | awk -F/ '{print $1}')
+		END_POS=$(mpc playlist | wc -l)
+		mpc add "$1"
+		mpc move $(($END_POS+1)) $(($CUR_POS+1))	
+		mpc play $(($CUR_POS+1))
 
 	#at least 1 song is in the playlist, determine the position of the 
 	#currently played song and add $1 after it
 	else
 
-		CUR_POS=$(mpc -p 6601 | tail -2 | head -1 | awk '{print $2}' | sed 's/#//' | awk -F/ '{print $1}')
-		END_POS=$(mpc -p 6601 playlist | wc -l)
-		mpc -p 6601 add "$1"
-		mpc -p 6601 move $(($END_POS+1)) $(($CUR_POS+1))	
-		mpc -p 6601 play $(($CUR_POS+1))
+		CUR_POS=$(mpc | tail -2 | head -1 | awk '{print $2}' | sed 's/#//' | awk -F/ '{print $1}')
+		END_POS=$(mpc playlist | wc -l)
+		mpc add "$1"
+		mpc move $(($END_POS+1)) $(($CUR_POS+1))	
+		mpc play $(($CUR_POS+1))
 	fi
 }
 
@@ -70,39 +70,39 @@ case $1 in
 	
 	while true; do
 
-		ARTIST="$(mpc -p 6601 list artist | sort -f | $ROFI)";
+		ARTIST="$(mpc list artist | sort -f | $ROFI)";
 		if [ "$ARTIST" = "" ]; then $ESC_ACTION; fi
 		
 		while true; do
 
-			ALBUMS=$(mpc -p 6601 list album artist "$ARTIST" | sort -f);
+			ALBUMS=$(mpc list album artist "$ARTIST" | sort -f);
 			ALBUM=$(echo -e "replace all\nadd all\n--------------------------\n$ALBUMS" | $ROFI);
 			if [ "$ALBUM" = "" ]; then $ESC_ACTION;
 			
 			elif [ "$ALBUM" = "replace all" ]; then
-				CUR_SONG=$(mpc -p 6601 current)
-				mpc -p 6601 clear
-				mpc -p 6601 find artist "$ARTIST" | mpc -p 6601 add 
-				if [ -n "$CUR_SONG" ]; then mpc -p 6601  play; fi
+				CUR_SONG=$(mpc current)
+				mpc clear
+				mpc find artist "$ARTIST" | mpc add 
+				if [ -n "$CUR_SONG" ]; then mpc  play; fi
 				$ESC_ACTION
 			elif [ "$ALBUM" = "add all" ]; then 
-				mpc -p 6601 find artist "$ARTIST" | mpc -p 6601 add
+				mpc find artist "$ARTIST" | mpc add
 				$ESC_ACTION
 			fi
 			
 			while true; do
 				
-				TITLES=$(mpc -p 6601 list title artist "$ARTIST" album "$ALBUM")
+				TITLES=$(mpc list title artist "$ARTIST" album "$ALBUM")
 				TITLE=$(echo -e "replace all\nadd all\n--------------------------\n$TITLES" | $ROFI);
 				if [ "$TITLE" = "" ]; then $ESC_ACTION
 				elif [ "$TITLE" = "replace all" ]; then
-					CUR_SONG=$(mpc -p 6601 current)
-					mpc -p 6601 clear;
-					mpc -p 6601 find artist "$ARTIST" album "$ALBUM" | mpc -p 6601 add 
-					if [ -n "$CUR_SONG" ]; then mpc -p 6601 play; fi
+					CUR_SONG=$(mpc current)
+					mpc clear;
+					mpc find artist "$ARTIST" album "$ALBUM" | mpc add 
+					if [ -n "$CUR_SONG" ]; then mpc play; fi
 					$ESC_ACTION
 				elif [ "$TITLE" = "add all" ]; then
-					mpc -p 6601 find artist "$ARTIST" album "$ALBUM" | mpc -p 6601 add 
+					mpc find artist "$ARTIST" album "$ALBUM" | mpc add 
 					$ESC_ACTION
 				
 				fi
@@ -116,22 +116,22 @@ case $1 in
 						;;
 
 						"add after current and play")
-						addaftercurrentandplay "$(mpc -p 6601 find artist "$ARTIST" album "$ALBUM" title "$TITLE" | head -1 )"
+						addaftercurrentandplay "$(mpc find artist "$ARTIST" album "$ALBUM" title "$TITLE" | head -1 )"
 						;;
 
 						"add after current")
-						addaftercurrent "$(mpc -p 6601 find artist "$ARTIST" album "$ALBUM" title "$TITLE" | head -1 )"
+						addaftercurrent "$(mpc find artist "$ARTIST" album "$ALBUM" title "$TITLE" | head -1 )"
 						;;
 
 						"replace")
-						CUR_SONG=$(mpc -p 6601 current)
-						mpc -p 6601 clear
-						mpc -p 6601 find artist "$ARTIST" album "$ALBUM" title "$TITLE" | head -1 | mpc -p 6601 add
-						if [ -n "$CUR_SONG" ]; then mpc -p 6601 play; fi
+						CUR_SONG=$(mpc current)
+						mpc clear
+						mpc find artist "$ARTIST" album "$ALBUM" title "$TITLE" | head -1 | mpc add
+						if [ -n "$CUR_SONG" ]; then mpc play; fi
 						;;
 						
 						"add at the end")
-						mpc -p 6601 find artist "$ARTIST" album "$ALBUM" title "$TITLE" | head -1 | mpc -p 6601 add
+						mpc find artist "$ARTIST" album "$ALBUM" title "$TITLE" | head -1 | mpc add
 						;;
 
 					esac
@@ -144,51 +144,51 @@ case $1 in
 
 	-t|--track)
 		
-	TITLE=$(mpc -p 6601 list title | sort -f | $ROFI)
+	TITLE=$(mpc list title | sort -f | $ROFI)
 	if [ "$TITLE" = "" ]; then exit; fi
 	
-	SONG=$(mpc -p 6601 find title "$TITLE" | head -1) 
+	SONG=$(mpc find title "$TITLE" | head -1) 
 	addaftercurrentandplay "$SONG"
 	;;
 
 	-p|--playlist)
-	PLAYLIST=$(mpc -p 6601 lsplaylists | $ROFI);
+	PLAYLIST=$(mpc lsplaylists | $ROFI);
 	if [ "$PLAYLIST" = "" ]; then exit; fi
-	CUR_SONG=$(mpc -p 6601 current)
-	mpc -p 6601 clear
-	mpc -p 6601 load "$PLAYLIST";
-	if [ -n "$CUR_SONG" ]; then mpc -p 6601 play; fi
+	CUR_SONG=$(mpc current)
+	mpc clear
+	mpc load "$PLAYLIST";
+	if [ -n "$CUR_SONG" ]; then mpc play; fi
 	;;
 
 	-j|--jump)
 	
-	TITLE=$(mpc -p 6601 playlist | $ROFI);
+	TITLE=$(mpc playlist | $ROFI);
 	if [ "$TITLE" = "" ]; then exit; fi
-	POS=$(mpc -p 6601 playlist | grep -n "$TITLE" | awk -F: '{print $1}')
-	mpc -p 6601 play $POS;
+	POS=$(mpc playlist | grep -n "$TITLE" | awk -F: '{print $1}')
+	mpc play $POS;
 	;;
 
 	-l|--longplayer)
 	
 	while true; do
 
-		ALBUM=$(mpc -p 6601 list album | sort -f | $ROFI);
+		ALBUM=$(mpc list album | sort -f | $ROFI);
 		if [ "$ALBUM" = "" ]; then $ESC_ACTION;
 		fi
 		
 		while true; do
 			
-			TITLES=$(mpc -p 6601 list title album "$ALBUM")
+			TITLES=$(mpc list title album "$ALBUM")
 			TITLE=$(echo -e "replace all\nadd all\n--------------------------\n$TITLES" | $ROFI);
 			if [ "$TITLE" = "" ]; then $ESC_ACTION
 			elif [ "$TITLE" = "replace all" ]; then
-				CUR_SONG=$(mpc -p 6601 current)
-				mpc -p 6601 clear;
-				mpc -p 6601 find album "$ALBUM" | mpc -p 6601 add 
-				if [ -n "$CUR_SONG" ]; then mpc -p 6601 play; fi
+				CUR_SONG=$(mpc current)
+				mpc clear;
+				mpc find album "$ALBUM" | mpc add 
+				if [ -n "$CUR_SONG" ]; then mpc play; fi
 				$ESC_ACTION
 			elif [ "$TITLE" = "add all" ]; then
-				mpc -p 6601 find album "$ALBUM" | mpc -p 6601 add 
+				mpc find album "$ALBUM" | mpc add 
 				$ESC_ACTION
 			
 			fi
@@ -202,22 +202,22 @@ case $1 in
 					;;
 
 					"add after current and play")
-					addaftercurrentandplay "$(mpc -p 6601 find album "$ALBUM" title "$TITLE" | head -1 )"
+					addaftercurrentandplay "$(mpc find album "$ALBUM" title "$TITLE" | head -1 )"
 					;;
 
 					"add after current")
-					addaftercurrent "$(mpc -p 6601 find album "$ALBUM" title "$TITLE" | head -1 )"
+					addaftercurrent "$(mpc find album "$ALBUM" title "$TITLE" | head -1 )"
 					;;
 
 					"replace")
-					CUR_SONG=$(mpc -p 6601 current)
-					mpc -p 6601 clear
-					mpc -p 6601 find album "$ALBUM" title "$TITLE" | head -1 | mpc -p 6601 add
-					if [ -n "$CUR_SONG" ]; then mpc -p 6601 play; fi
+					CUR_SONG=$(mpc current)
+					mpc clear
+					mpc find album "$ALBUM" title "$TITLE" | head -1 | mpc add
+					if [ -n "$CUR_SONG" ]; then mpc play; fi
 					;;
 					
 					"add at the end")
-					mpc -p 6601 find album "$ALBUM" title "$TITLE" | head -1 | mpc -p 6601 add
+					mpc find album "$ALBUM" title "$TITLE" | head -1 | mpc add
 					;;
 
 				esac


### PR DESCRIPTION
This is better than the other PR's about port numbers. Editing the source file to support own port is worst way than setting default env variable for the mpc port.